### PR TITLE
update to openssl 3.0.9 certified on 20240123

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-ARG OPENSSL_VERSION=3.0.8
+ARG OPENSSL_VERSION=3.0.9
 
 RUN apk add --no-cache --virtual .build-deps \
     make gcc libgcc musl-dev linux-headers perl vim \


### PR DESCRIPTION
https://www.openssl.org/blog/blog/2024/01/23/fips-309/