### PR TITLE
cd .. before rm -rf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN apk add --no-cache --virtual .build-deps \
     && make \
     && make install_fips \
     && apk del .build-deps \
-    && rm -rf openssl-${OPENSSL_VERSION}.tar.gz openssl-${OPENSSL_VERSION}
+    && cd .. && rm -rf openssl-${OPENSSL_VERSION}.tar.gz openssl-${OPENSSL_VERSION}
 
 COPY openssl.cnf /etc/ssl/openssl.cnf


### PR DESCRIPTION
The folder and the .tar.gz don't get deleted properly when building the container because you are inside of the openssl folder via
````
cd openssl-${OPENSSL_VERSION}
````

Doing a
````
cd ..
````

Fixes this issue for the cleanup.